### PR TITLE
Allow configuration of collection feed's title and backing collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* add option to set a collection feed's title and backing collection
+
 ...
 
 ## 3.1.2 / 2024-03-02

--- a/README.md
+++ b/README.md
@@ -188,6 +188,15 @@ feed:
       path: "/changes.xml"
 ```
 
+By default, collection feeds will have a title based on the collection name. If you'd like to customize the feed title, specify a collection's title as follows:
+
+```yml
+feed:
+  collections:
+    changes:
+      title: "Recent Changes"
+```
+
 Finally, collections can also have category feeds which are outputted as `/feed/<COLLECTION>/<CATEGORY>.xml`. Specify categories like so:
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ By default, collection feeds will have a title based on the collection name. If 
 feed:
   collections:
     changes:
-      title: "Recent Changes"
+      title: Recent Changes
 ```
 
 By default, collection feeds will use the same collection as the configuration key. If you'd like to customize the collection, or have multiple configurations for a single collection, specify as follows:
@@ -203,9 +203,9 @@ By default, collection feeds will use the same collection as the configuration k
 feed:
   collections:
     my_feed:
-      collection: "posts"
+      collection: posts
     daily_email: # single article feed for daily email automation
-      collection: "posts"
+      collection: posts
       limit: 1
 ```
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,18 @@ feed:
       title: "Recent Changes"
 ```
 
+By default, collection feeds will use the same collection as the configuration key. If you'd like to customize the collection, or have multiple configurations for a single collection, specify as follows:
+
+```yml
+feed:
+  collections:
+    my_feed:
+      collection: "posts"
+    daily_email: # single article feed for daily email automation
+      collection: "posts"
+      limit: 1
+```
+
 Finally, collections can also have category feeds which are outputted as `/feed/<COLLECTION>/<CATEGORY>.xml`. Specify categories like so:
 
 ```yml

--- a/lib/bridgetown-feed/feed.xml
+++ b/lib/bridgetown-feed/feed.xml
@@ -38,7 +38,7 @@
     </author>
   {% endif %}
 
-  {% assign feed_collection = collections[page.collection] %}
+  {% assign feed_collection = collections[page.feed_meta.collection] %}
   {% find posts where feed_collection.resources, draft != true %}
   {% if page.category %}
     {% assign posts = posts | where: "category",page.category %}

--- a/lib/bridgetown-feed/feed.xml
+++ b/lib/bridgetown-feed/feed.xml
@@ -10,9 +10,8 @@
   <id>{{ page.url | absolute_url | xml_escape }}</id>
 
   {% assign title = site.metadata.title | default: site.metadata.name %}
-  {% if page.collection != "posts" %}
-    {% assign collection = page.collection | capitalize %}
-    {% assign title = title | append: " | " | append: collection %}
+  {% if page.feed_meta.title and page.feed_meta.title != "Posts" %}
+    {% assign title = title | append: " | " | append: page.feed_meta.title %}
   {% endif %}
   {% if page.category %}
     {% assign category = page.category | capitalize %}
@@ -44,7 +43,7 @@
   {% if page.category %}
     {% assign posts = posts | where: "category",page.category %}
   {% endif %}
-  {% assign post_limit = site.feed.collections[page.collection].post_limit | default: site.feed.post_limit | default: 10 %}
+  {% assign post_limit = page.feed_meta.post_limit | default: site.feed.post_limit | default: 10 %}
   {% for post in posts limit: post_limit %}
     {% assign post_id = post.data.id | default: post.id %}
     <entry{% if post.lang %}{{" "}}xml:lang="{{ post.lang }}"{% endif %}>

--- a/lib/bridgetown-feed/generator.rb
+++ b/lib/bridgetown-feed/generator.rb
@@ -13,7 +13,8 @@ module BridgetownFeed
           path = feed_path(collection: name, category: category)
           next if file_exists?(path)
 
-          @site.generated_pages << make_page(path, collection: name, category: category)
+          @site.generated_pages << make_page(path, feed_meta: meta, collection: name,
+category: category)
         end
       end
     end
@@ -61,8 +62,9 @@ module BridgetownFeed
                      end
 
       @collections = normalize_posts_meta(@collections)
-      @collections.each_value do |meta|
+      @collections.each_pair do |key, meta|
         meta["categories"] = (meta["categories"] || []).to_set
+        meta["title"] ||= key.capitalize
       end
 
       @collections
@@ -84,7 +86,7 @@ module BridgetownFeed
 
     # Generates contents for a file
 
-    def make_page(file_path, collection: "posts", category: nil)
+    def make_page(file_path, feed_meta:, collection: "posts", category: nil)
       Bridgetown::GeneratedPage.new(@site, __dir__, "", file_path, from_plugin: true).tap do |file|
         file.content = feed_template
         file.data.merge!(
@@ -94,7 +96,8 @@ module BridgetownFeed
           "sitemap"         => false,
           "xsl"             => file_exists?("feed.xslt.xml"),
           "collection"      => collection,
-          "category"        => category
+          "category"        => category,
+          "feed_meta"       => feed_meta
         )
         file.output
       end

--- a/lib/bridgetown-feed/generator.rb
+++ b/lib/bridgetown-feed/generator.rb
@@ -13,8 +13,7 @@ module BridgetownFeed
           path = feed_path(collection: name, category: category)
           next if file_exists?(path)
 
-          @site.generated_pages << make_page(path, feed_meta: meta, collection: name,
-category: category)
+          @site.generated_pages << make_page(path, feed_meta: meta, category: category)
         end
       end
     end
@@ -65,6 +64,7 @@ category: category)
       @collections.each_pair do |key, meta|
         meta["categories"] = (meta["categories"] || []).to_set
         meta["title"] ||= key.capitalize
+        meta["collection"] ||= key
       end
 
       @collections
@@ -86,7 +86,7 @@ category: category)
 
     # Generates contents for a file
 
-    def make_page(file_path, feed_meta:, collection: "posts", category: nil)
+    def make_page(file_path, feed_meta:, category: nil)
       Bridgetown::GeneratedPage.new(@site, __dir__, "", file_path, from_plugin: true).tap do |file|
         file.content = feed_template
         file.data.merge!(
@@ -95,7 +95,6 @@ category: category)
           "template_engine" => "liquid",
           "sitemap"         => false,
           "xsl"             => file_exists?("feed.xslt.xml"),
-          "collection"      => collection,
           "category"        => category,
           "feed_meta"       => feed_meta
         )

--- a/spec/bridgetown-feed_spec.rb
+++ b/spec/bridgetown-feed_spec.rb
@@ -583,4 +583,42 @@ describe(BridgetownFeed) do
       end
     end
   end
+
+  describe "feed title override" do
+    let(:feed) { RSS::Parser.parse(contents) }
+
+    context "with posts collection" do
+      let(:overrides) do
+        {
+          "feed" => {
+            "collections" => {
+              "posts" => {}
+            }
+          },
+        }
+      end
+
+      it "doesn't include a posts title" do
+        expect(feed.title.content).not_to include "Posts"
+      end
+    end
+
+    context "with feed title override" do
+      let(:overrides) do
+        {
+          "feed" => {
+            "collections" => {
+              "posts" => {
+                "title": "My Feed"
+              },
+            },
+          },
+        }
+      end
+
+      it "includes the custom title" do
+        expect(feed.title.content).to include "My Feed"
+      end
+    end
+  end
 end

--- a/spec/bridgetown-feed_spec.rb
+++ b/spec/bridgetown-feed_spec.rb
@@ -621,4 +621,40 @@ describe(BridgetownFeed) do
       end
     end
   end
+
+  describe "feed collection override" do
+    context "without specifing the collection" do
+      let(:overrides) do
+        {
+          "feed" => {
+            "collections" => {
+              "posts" => {}
+            }
+          },
+        }
+      end
+
+      it "uses the key name as the collection" do
+        expect(config.feed.collections.posts.collection).to eq "posts"
+      end
+    end
+
+    context "without specifing the collection" do
+      let(:overrides) do
+        {
+          "feed" => {
+            "collections" => {
+              "my_posts" => {
+                "collection" => "posts"
+              }
+            }
+          },
+        }
+      end
+
+      it "uses the key name as the collection" do
+        expect(config.feed.collections.my_posts.collection).to eq "posts"
+      end
+    end
+  end
 end


### PR DESCRIPTION
I want to be able to create multiple feeds for the same collection, a main feed, and a feed with a single item for automation. This gives the option to do that.

```yml
feed:
  collections:
    feed:
       collection: posts
    daily_email:
       collection: posts
       limit: 1
```